### PR TITLE
Add spell icon options

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -21,6 +21,7 @@ local DefaultPresets = {
         attachModeFallback = true,
         spellIconOffsetX = 0,
         spellIconOffsetY = 0,
+        spellIconZoom = 1,
         abbreviateNumbers = false,
         kiloSeparator = false,
         filterAbsoluteEnabled = false,
@@ -509,6 +510,7 @@ local DefaultPresets = {
         attachModeFallback = true,
         spellIconOffsetX = 0,
         spellIconOffsetY = 0,
+        spellIconZoom = 1,
         abbreviateNumbers = false,
         kiloSeparator = false,
         filterAbsoluteEnabled = false,
@@ -2223,9 +2225,10 @@ local spacingSliderY = ConfigPanel:CreateSlider("Anti-Overlap Vertical Spacing",
 local spellIconOptionsHeader = ConfigPanel:CreateHeader("Spell Icon Options", "GameFontNormalLarge", textPosOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 0, -200)
 local iconOffsetSliderX = ConfigPanel:CreateSlider("X Offset", "Horizontal offset of spell icon", spellIconOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 20, -24, -20, 20, 1, DefaultConfig.spellIconOffsetX, "Config.spellIconOffsetX")
 local iconOffsetSliderY = ConfigPanel:CreateSlider("Y Offset", "Vertical offset of spell icon", iconOffsetSliderX, "LEFT", "RIGHT", 16, 0, -20, 20, 1, DefaultConfig.spellIconOffsetY, "Config.spellIconOffsetY")
+local iconZoomSlider = ConfigPanel:CreateSlider("Zoom", "Zoom in on the icon and trim to edge to give a more square appearance", iconOffsetSliderX, "TOPLEFT", "BOTTOMLEFT", 0, -28, 1, 2, 0.01, DefaultConfig.spellIconZoom, "Config.spellIconZoom")
 
 
-local textFormatOptionsHeader = ConfigPanel:CreateHeader("Number Formatting Options", "GameFontNormalLarge", spellIconOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 0, -64)
+local textFormatOptionsHeader = ConfigPanel:CreateHeader("Number Formatting Options", "GameFontNormalLarge", spellIconOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 0, -108)
 local abbrevCheckbox = ConfigPanel:CreateCheckbox("Abbreviate Large Numbers", "Abbreviate large numbers (ex.1K)", textFormatOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 20, -8, DefaultConfig.abbreviateNumbers, "Config.abbreviateNumbers")
 local kiloSepCheckbox = ConfigPanel:CreateCheckbox("Add Thousands Separator", "Add thousands separator (ex.100,000,000)", abbrevCheckbox, "TOPLEFT", "BOTTOMLEFT", 0, 0, DefaultConfig.kiloSeparator, "Config.kiloSeparator")
 

--- a/config.lua
+++ b/config.lua
@@ -19,6 +19,8 @@ local DefaultPresets = {
         preventOverlapSpacingY = 50,
         attachMode = "tn",
         attachModeFallback = true,
+        spellIconOffsetX = 0,
+        spellIconOffsetY = 0,
         abbreviateNumbers = false,
         kiloSeparator = false,
         filterAbsoluteEnabled = false,
@@ -505,6 +507,8 @@ local DefaultPresets = {
         preventOverlapSpacingY = 50,
         attachMode = "tn",
         attachModeFallback = true,
+        spellIconOffsetX = 0,
+        spellIconOffsetY = 0,
         abbreviateNumbers = false,
         kiloSeparator = false,
         filterAbsoluteEnabled = false,
@@ -2214,7 +2218,14 @@ local areaSliderNY = ConfigPanel:CreateSlider("Nameplate Text Y Offset", "Vertic
 local spacingSliderX = ConfigPanel:CreateSlider("Anti-Overlap Horizontal Spacing", "Horizontal spacing between text", areaSliderNX, "TOPLEFT", "BOTTOMLEFT", 0, -28, 0, 200, 1, DefaultConfig.preventOverlapSpacingX, "Config.preventOverlapSpacingX")
 local spacingSliderY = ConfigPanel:CreateSlider("Anti-Overlap Vertical Spacing", "Vertical spacing between text", spacingSliderX, "LEFT", "RIGHT", 16, 0, 0, 200, 1, DefaultConfig.preventOverlapSpacingY, "Config.preventOverlapSpacingY")
 
-local textFormatOptionsHeader = ConfigPanel:CreateHeader("Number Formatting Options", "GameFontNormalLarge", textPosOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 0, -200)
+
+-- Spell Icon Options
+local spellIconOptionsHeader = ConfigPanel:CreateHeader("Spell Icon Options", "GameFontNormalLarge", textPosOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 0, -200)
+local iconOffsetSliderX = ConfigPanel:CreateSlider("X Offset", "Horizontal offset of spell icon", spellIconOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 20, -24, -20, 20, 1, DefaultConfig.spellIconOffsetX, "Config.spellIconOffsetX")
+local iconOffsetSliderY = ConfigPanel:CreateSlider("Y Offset", "Vertical offset of spell icon", iconOffsetSliderX, "LEFT", "RIGHT", 16, 0, -20, 20, 1, DefaultConfig.spellIconOffsetY, "Config.spellIconOffsetY")
+
+
+local textFormatOptionsHeader = ConfigPanel:CreateHeader("Number Formatting Options", "GameFontNormalLarge", spellIconOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 0, -64)
 local abbrevCheckbox = ConfigPanel:CreateCheckbox("Abbreviate Large Numbers", "Abbreviate large numbers (ex.1K)", textFormatOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 20, -8, DefaultConfig.abbreviateNumbers, "Config.abbreviateNumbers")
 local kiloSepCheckbox = ConfigPanel:CreateCheckbox("Add Thousands Separator", "Add thousands separator (ex.100,000,000)", abbrevCheckbox, "TOPLEFT", "BOTTOMLEFT", 0, 0, DefaultConfig.kiloSeparator, "Config.kiloSeparator")
 

--- a/config.lua
+++ b/config.lua
@@ -22,6 +22,7 @@ local DefaultPresets = {
         spellIconOffsetX = 0,
         spellIconOffsetY = 0,
         spellIconZoom = 1,
+        spellIconAspectRatio = 1,
         abbreviateNumbers = false,
         kiloSeparator = false,
         filterAbsoluteEnabled = false,
@@ -511,6 +512,7 @@ local DefaultPresets = {
         spellIconOffsetX = 0,
         spellIconOffsetY = 0,
         spellIconZoom = 1,
+        spellIconAspectRatio = 1,
         abbreviateNumbers = false,
         kiloSeparator = false,
         filterAbsoluteEnabled = false,
@@ -2226,6 +2228,7 @@ local spellIconOptionsHeader = ConfigPanel:CreateHeader("Spell Icon Options", "G
 local iconOffsetSliderX = ConfigPanel:CreateSlider("X Offset", "Horizontal offset of spell icon", spellIconOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 20, -24, -20, 20, 1, DefaultConfig.spellIconOffsetX, "Config.spellIconOffsetX")
 local iconOffsetSliderY = ConfigPanel:CreateSlider("Y Offset", "Vertical offset of spell icon", iconOffsetSliderX, "LEFT", "RIGHT", 16, 0, -20, 20, 1, DefaultConfig.spellIconOffsetY, "Config.spellIconOffsetY")
 local iconZoomSlider = ConfigPanel:CreateSlider("Zoom", "Zoom in on the icon and trim to edge to give a more square appearance", iconOffsetSliderX, "TOPLEFT", "BOTTOMLEFT", 0, -28, 1, 2, 0.01, DefaultConfig.spellIconZoom, "Config.spellIconZoom")
+local iconAspectRatioSlider = ConfigPanel:CreateSlider("Aspect Ratio", "Aspect ratio of spell icon", iconZoomSlider, "LEFT", "RIGHT", 16, 0, 1, 2, 0.01, DefaultConfig.spellIconAspectRatio, "Config.spellIconAspectRatio")
 
 
 local textFormatOptionsHeader = ConfigPanel:CreateHeader("Number Formatting Options", "GameFontNormalLarge", spellIconOptionsHeader, "TOPLEFT", "BOTTOMLEFT", 0, -108)

--- a/main.lua
+++ b/main.lua
@@ -593,14 +593,17 @@ local function SpellIconText(spellid)
     local fctConfig = CFCT.Config
     local tx = select(3,GetSpellInfo(spellid))
     if tx then
-        local height, width = 0, 0
+        local aspectRatio = fctConfig.spellIconAspectRatio
         local zoom = fctConfig.spellIconZoom
         local offsetX, offsetY = fctConfig.spellIconOffsetX, fctConfig.spellIconOffsetY
+        local height, width = 12 / aspectRatio, 12
         local txSize = zoom * 100
-        local txMin = (zoom - 1) * 100 / 2
-        local txMax = (zoom + 1) * 100 / 2
+        local txMinX = (zoom - 1) * 100 / 2
+        local txMaxX = (zoom + 1) * 100 / 2
+        local txMinY = (zoom - (1 / aspectRatio)) * 100 / 2
+        local txMaxY = (zoom + (1 / aspectRatio)) * 100 / 2
         return string.format("|T%s:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d|t",
-            tx, height, width, offsetX, offsetY, txSize, txSize, txMin, txMax, txMin, txMax)
+            tx, height, width, offsetX, offsetY, txSize, txSize, txMinX, txMaxX, txMinY, txMaxY)
     end
     return false
 end

--- a/main.lua
+++ b/main.lua
@@ -594,9 +594,13 @@ local function SpellIconText(spellid)
     local tx = select(3,GetSpellInfo(spellid))
     if tx then
         local height, width = 0, 0
+        local zoom = fctConfig.spellIconZoom
         local offsetX, offsetY = fctConfig.spellIconOffsetX, fctConfig.spellIconOffsetY
-        return string.format("|T%s:%d:%d:%d:%d|t",
-            tx, height, width, offsetX, offsetY)
+        local txSize = zoom * 100
+        local txMin = (zoom - 1) * 100 / 2
+        local txMax = (zoom + 1) * 100 / 2
+        return string.format("|T%s:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d|t",
+            tx, height, width, offsetX, offsetY, txSize, txSize, txMin, txMax, txMin, txMax)
     end
     return false
 end

--- a/main.lua
+++ b/main.lua
@@ -590,8 +590,14 @@ end
 
 
 local function SpellIconText(spellid)
+    local fctConfig = CFCT.Config
     local tx = select(3,GetSpellInfo(spellid))
-    if tx then return "|T"..tx..":0|t" end
+    if tx then
+        local height, width = 0, 0
+        local offsetX, offsetY = fctConfig.spellIconOffsetX, fctConfig.spellIconOffsetY
+        return string.format("|T%s:%d:%d:%d:%d|t",
+            tx, height, width, offsetX, offsetY)
+    end
     return false
 end
 


### PR DESCRIPTION
I wanted to add a few options to spell icons for my personal use and figured I'd see if they were changes you're interested in incorporating. Specifically, I've added an icon position offset, the ability to zoom the icon slightly, and the ability to change the aspect ratio to make the icon rectangular.

I've done my best to match the existing style and not to touch anything that wasn't absolutely necessary. I'm more than happy to adjust my changes as desired.

I've tested moderately well, though I'll be testing it more thoroughly tonight during raid.

Here's the new section in the configuration UI
![image](https://user-images.githubusercontent.com/484784/136478906-ccadbc13-515f-488f-9424-64f26f4daf43.png)

Comparison with an X offset applied
![image](https://user-images.githubusercontent.com/484784/136478956-8e82be89-889c-4680-9cf6-9f240d915515.png)

Comparison with a slight zoom applied
![image](https://user-images.githubusercontent.com/484784/136478982-9a8389fa-57af-44bb-85a7-96e8267c23ab.png)

Comparison with aspect ratio adjusted
![image](https://user-images.githubusercontent.com/484784/136479016-abf751c0-5541-48a0-adfc-430cd40edb8f.png)

Let me know if you're open to these sorts of contributions. I have a couple of other small changes I may end up making.